### PR TITLE
Fix output formatting

### DIFF
--- a/src/main/java/io/github/eliux/mega/MegaUtils.java
+++ b/src/main/java/io/github/eliux/mega/MegaUtils.java
@@ -45,6 +45,8 @@ public interface MegaUtils {
       case 51:  //Win
       case 2:   //Unix
         throw new MegaWrongArgumentsException();
+      case 12:
+        throw new MegaResourceAlreadyExistsException();
       case 52:
         throw new MegaInvalidEmailException();
       case 53:

--- a/src/main/java/io/github/eliux/mega/cmd/ExportInfo.java
+++ b/src/main/java/io/github/eliux/mega/cmd/ExportInfo.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 public class ExportInfo {
 
     private static final Pattern LIST_PATTERN =
-            Pattern.compile("(?<remotePath>\\S+) \\(.+link: (?<publicLink>http[s]?://mega.nz/#.+)\\)");
+            Pattern.compile("(?<remotePath>\\S+) \\(.+link: (?<publicLink>http[s]?://mega.nz/\\S*#.+)\\)");
 
     private final String remotePath;
 

--- a/src/main/java/io/github/eliux/mega/error/MegaResourceAlreadyExistsException.java
+++ b/src/main/java/io/github/eliux/mega/error/MegaResourceAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package io.github.eliux.mega.error;
+
+public class MegaResourceAlreadyExistsException extends MegaWrongArgumentsException {
+
+  public MegaResourceAlreadyExistsException() {
+    super("Existent resource");
+  }
+}
+

--- a/src/test/java/io/github/eliux/mega/cmd/BasicActionsTest.java
+++ b/src/test/java/io/github/eliux/mega/cmd/BasicActionsTest.java
@@ -22,13 +22,22 @@ public class BasicActionsTest {
   @BeforeClass
   public static void setupSession() {
     sessionMega = Mega.init();
+    removeTestResourcesIfExist();
   }
 
   @AfterClass
   public static void finishSession() {
-    sessionMega.removeDirectory("megacmd4j").run();
-    sessionMega.remove("yolo*.txt").ignoreErrorIfNotPresent().run();
+    removeTestResourcesIfExist();
     sessionMega.logout();
+  }
+
+  private static void removeTestResourcesIfExist() {
+    sessionMega.removeDirectory("megacmd4j")
+        .ignoreErrorIfNotPresent()
+        .run();
+    sessionMega.remove("yolo*.txt")
+        .ignoreErrorIfNotPresent()
+        .run();
   }
 
   @Test
@@ -64,7 +73,8 @@ public class BasicActionsTest {
         "You only live once..."
     );
 
-    sessionMega.uploadFile("target/yolo-test.txt").run();
+    sessionMega.uploadFile("target/yolo-test.txt")
+        .run();
 
     MegaTestUtils.removeFile("target/yolo-test.txt");
   }

--- a/src/test/java/io/github/eliux/mega/cmd/ExportInfoTest.java
+++ b/src/test/java/io/github/eliux/mega/cmd/ExportInfoTest.java
@@ -83,7 +83,7 @@ public class ExportInfoTest {
     //Given
     String responseWithRemotePathWithSubPaths =
         "megacmd4j/level2/level3 (folder, shared as exported permanent " +
-            "folder link: https://mega.nz/#F!APJmCbiJ!lfKu3tVd8pNceLoH6qe_tA)";
+            "folder link: https://mega.nz/folder/xSx1ybja#cBos0Ly_71GXu6v-rKZXzg)";
 
     //When
     final ExportInfo exportInfo =
@@ -92,7 +92,7 @@ public class ExportInfoTest {
     //Then
     Assert.assertEquals("megacmd4j/level2/level3", exportInfo.getRemotePath());
     Assert.assertEquals(
-        "https://mega.nz/#F!APJmCbiJ!lfKu3tVd8pNceLoH6qe_tA",
+        "https://mega.nz/folder/xSx1ybja#cBos0Ly_71GXu6v-rKZXzg",
         exportInfo.getPublicLink()
     );
   }


### PR DESCRIPTION
Map exit value 12 to `MegaResourceAlreadyExistsException`: More details when catching errors.
Fix parsing of command output when exporting link.
      
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
A new case with the nw
Tests have passed