### PR TITLE
Allow option  to export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/
 pom.xml.releaseBackup
 release.properties
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Before 1.6.0 - 2020-09-08
+### Added
+- Added option `expire date` to `export`
 ## Before 1.5.0 - 2020-07-21
 ### Added
-- Add support for command `import`
+- Added support for command `import`
 - Added `option` password to `export`
 ## Before 1.4.0 - 2019-05-24
 ### Update

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ indicates any non null response. E.g.
 ```java
     sessionMega.exists("remote/path/filesprefix*.ext");
 ```
+
+### Export with an expiration date
+With a premium mega account, you can export and generate public folder links by setting the option `expire date`.
+```java
+    LocalDate expireDate = LocalDate.of(2020, 9, 2);
+    final ExportInfo exportInfo = sessionMega.export(exportFolder)
+            .setExpireDate(expireDate)
+            .call();
+```
+
+or you can just specify a duration using `TimeDelay`.
+
+```java  
+    final ExportInfo exportInfo = sessionMega.export(exportFolder)
+        .setExpirationTimeDelay(TimeDelay.of(
+             Period.ofYears(3).plusMonths(11).plusDays(15)
+         ))
+        .call();
+```
+
 ### MEGAcmdServer
 Thanks to the class `io.github.eliux.mega.MegaServer` you can now `start` and `stop` the local MEGAcmdServer on command.
 

--- a/src/main/java/io/github/eliux/mega/MegaUtils.java
+++ b/src/main/java/io/github/eliux/mega/MegaUtils.java
@@ -3,6 +3,7 @@ package io.github.eliux.mega;
 import io.github.eliux.mega.error.*;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;

--- a/src/main/java/io/github/eliux/mega/MegaUtils.java
+++ b/src/main/java/io/github/eliux/mega/MegaUtils.java
@@ -1,16 +1,29 @@
 package io.github.eliux.mega;
 
-import io.github.eliux.mega.error.*;
+import static io.github.eliux.mega.Mega.CMD_TTL_ENV_VAR;
 
+import io.github.eliux.mega.error.MegaConfirmationRequiredException;
+import io.github.eliux.mega.error.MegaIOException;
+import io.github.eliux.mega.error.MegaInvalidEmailException;
+import io.github.eliux.mega.error.MegaInvalidStateException;
+import io.github.eliux.mega.error.MegaInvalidTypeException;
+import io.github.eliux.mega.error.MegaLoginRequiredException;
+import io.github.eliux.mega.error.MegaNodesNotFetchedException;
+import io.github.eliux.mega.error.MegaOperationNotAllowedException;
+import io.github.eliux.mega.error.MegaResourceAlreadyExistsException;
+import io.github.eliux.mega.error.MegaResourceNotFoundException;
+import io.github.eliux.mega.error.MegaUnexpectedFailureException;
+import io.github.eliux.mega.error.MegaWrongArgumentsException;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
-import static io.github.eliux.mega.Mega.CMD_TTL_ENV_VAR;
 
 public interface MegaUtils {
 
@@ -37,8 +50,8 @@ public interface MegaUtils {
 
   static void handleResult(int code) {
     int posixExitStatus = Optional.ofNullable(code)
-            .map(Math::abs)
-            .orElse(-1);
+        .map(Math::abs)
+        .orElse(-1);
     switch (posixExitStatus) {
       case 0:
         //Its Ok
@@ -71,7 +84,7 @@ public interface MegaUtils {
     }
   }
 
-  static String[] convertInstructionsToExecParams(String cmdInstructions){
+  static String[] convertInstructionsToExecParams(String cmdInstructions) {
     return cmdInstructions.split("\\s+");
   }
 
@@ -114,9 +127,9 @@ public interface MegaUtils {
   }
 
   static String execCmdWithSingleOutput(String... cmd) throws IOException {
-    try{
+    try {
       return handleCmdWithOutput(cmd).get(0);
-    }catch (IndexOutOfBoundsException ex){
+    } catch (IndexOutOfBoundsException ex) {
       return "";
     }
   }

--- a/src/main/java/io/github/eliux/mega/cmd/MegaCmdExport.java
+++ b/src/main/java/io/github/eliux/mega/cmd/MegaCmdExport.java
@@ -4,6 +4,10 @@ import io.github.eliux.mega.MegaUtils;
 import io.github.eliux.mega.error.MegaIOException;
 import io.github.eliux.mega.error.MegaInvalidResponseException;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -19,9 +23,12 @@ public class MegaCmdExport extends AbstractMegaCmdCallerWithParams<ExportInfo> {
 
   private boolean listOnly;
 
+  Optional<TimeDelay> expirationTimeDelay;
+
   public MegaCmdExport(String remotePath) {
     this.remotePath = Optional.of(remotePath);
     this.password = Optional.empty();
+    this.expirationTimeDelay = Optional.empty();
   }
 
   @Override
@@ -32,12 +39,14 @@ public class MegaCmdExport extends AbstractMegaCmdCallerWithParams<ExportInfo> {
         .filter(x -> !listOnly)
         .ifPresent(x -> {
           cmdParams.add(exportDeleted ? "-d" : "-a");
+          expirationTimeDelay.map(td -> String.format("--expire=%s", td))
+              .ifPresent(cmdParams::add);
           cmdParams.add("-f");
         });
 
-    remotePath.ifPresent(cmdParams::add);
-
     password.ifPresent(p -> cmdParams.add(String.format("--password=%s", p)));
+
+    remotePath.ifPresent(cmdParams::add);
 
     return cmdParams;
   }
@@ -93,6 +102,28 @@ public class MegaCmdExport extends AbstractMegaCmdCallerWithParams<ExportInfo> {
 
   public MegaCmdExport removePassword() {
     this.password = Optional.empty();
+    return this;
+  }
+
+  public MegaCmdExport setExpirationTimeDelay(TimeDelay expirationTimeDelay) {
+    this.expirationTimeDelay = Optional.of(expirationTimeDelay);
+    return this;
+  }
+
+  public MegaCmdExport setExpireDate(LocalDateTime endDateTimeExclusive) {
+    final Period period = Period.between(LocalDate.now(), endDateTimeExclusive.toLocalDate());
+    final Duration duration = Duration.between(LocalDateTime.now(), endDateTimeExclusive);
+
+    return this.setExpirationTimeDelay(TimeDelay.of(period, duration));
+  }
+
+  public MegaCmdExport setExpireDate(LocalDate date) {
+    final Period period = Period.between(LocalDate.now(), date);
+    return this.setExpirationTimeDelay(TimeDelay.of(period));
+  }
+
+  public MegaCmdExport withoutExpiration() {
+    this.expirationTimeDelay = Optional.empty();
     return this;
   }
 

--- a/src/main/java/io/github/eliux/mega/cmd/TimeDelay.java
+++ b/src/main/java/io/github/eliux/mega/cmd/TimeDelay.java
@@ -1,0 +1,151 @@
+package io.github.eliux.mega.cmd;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.time.temporal.ChronoUnit.NANOS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.YEARS;
+
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class TimeDelay implements TemporalAmount {
+
+  public static final TimeDelay ZERO = new TimeDelay(Period.ZERO, Duration.ZERO);
+  static final int HOURS_PER_DAY = 24;
+  static final int MINUTES_PER_HOUR = 60;
+  static final int SECONDS_PER_MINUTE = 60;
+  private static final List<TemporalUnit> SUPPORTED_UNITS =
+      Collections.unmodifiableList(
+          Arrays.<TemporalUnit>asList(YEARS, MONTHS, DAYS, HOURS, MINUTES, SECONDS, NANOS));
+  private final Period period;
+
+  private final Duration duration;
+
+  private TimeDelay(Period period, Duration duration) {
+    final Long durationDays = duration.toDays();
+    final int days = (durationDays == 0 ? period.getDays() : durationDays.intValue());
+    this.period = Period.of(period.getYears(), period.getMonths(), days);
+    this.duration = duration.minusDays(duration.toDays());
+  }
+
+
+  static TimeDelay of(Period period, Duration duration) {
+    return new TimeDelay(period, duration);
+  }
+
+
+  static TimeDelay of(Period period) {
+    return new TimeDelay(period, Duration.ZERO);
+  }
+
+  static TimeDelay of(Duration duration) {
+    return new TimeDelay(Period.ZERO, duration);
+  }
+
+  @Override
+  public long get(TemporalUnit unit) {
+    if (unit == ChronoUnit.YEARS) {
+      return this.period.getYears();
+    } else if (unit == ChronoUnit.MONTHS) {
+      return this.period.getMonths();
+    } else if (unit == ChronoUnit.DAYS) {
+      return this.period.getDays();
+    } else if (unit == ChronoUnit.HOURS) {
+      return this.toHours();
+    } else if (unit == ChronoUnit.MINUTES) {
+      return this.toMinutes();
+    } else if (unit == SECONDS) {
+      return this.toSeconds();
+    } else {
+      throw new UnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+  }
+
+  @Override
+  public List<TemporalUnit> getUnits() {
+    return SUPPORTED_UNITS;
+  }
+
+  @Override
+  public Temporal addTo(Temporal temporal) {
+    return this.period.addTo(this.duration.addTo(temporal));
+  }
+
+  @Override
+  public Temporal subtractFrom(Temporal temporal) {
+    return this.period.subtractFrom(this.duration.subtractFrom(temporal));
+  }
+
+  public Period getPeriod() {
+    return period;
+  }
+
+  public Duration getDuration() {
+    return duration;
+  }
+
+  public int toSeconds() {
+    return (int) (this.getDuration().getSeconds() % SECONDS_PER_MINUTE);
+  }
+
+  public int toMinutes() {
+    return (int) (this.getDuration().toMinutes() % MINUTES_PER_HOUR);
+  }
+
+  public int toHours() {
+    return (int) (this.getDuration().toHours() % HOURS_PER_DAY);
+  }
+
+
+  public String toString() {
+    if (this == TimeDelay.ZERO) {
+      return "0m";
+    } else {
+      StringBuilder buf = new StringBuilder();
+      final Period period = this.getPeriod();
+      if (period != Period.ZERO) {
+        if (period.getYears() != 0) {
+          buf.append(period.getYears()).append('y');
+        }
+
+        if (period.getMonths() != 0) {
+          buf.append(period.getMonths()).append('m');
+        }
+
+        if (period.getDays() != 0) {
+          buf.append(period.getDays()).append('d');
+        }
+      }
+      final Duration duration = this.getDuration();
+      if (duration != Duration.ZERO) {
+        final long hours = this.toHours();
+        if (hours != 0) {
+          buf.append(hours).append('h');
+        }
+
+        final long minutes = this.toMinutes();
+        if (minutes != 0) {
+          buf.append(minutes).append('m');
+        }
+
+        final int seconds = this.toSeconds();
+        if (seconds != 0) {
+          buf.append(seconds).append('s');
+        }
+      }
+
+      return buf.toString();
+    }
+  }
+}

--- a/src/test/java/io/github/eliux/mega/cmd/MegaCmdExportTest.java
+++ b/src/test/java/io/github/eliux/mega/cmd/MegaCmdExportTest.java
@@ -1,0 +1,50 @@
+package io.github.eliux.mega.cmd;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class MegaCmdExportTest {
+
+
+  @DisplayName("MegaCmdExport#setExpireDate using LocalDateTime should produce the right TimeDelay")
+  @Test
+  public void setExpireDateWithLocalDateTime() {
+    final Period period = Period.ofYears(1).plusMonths(11);
+    final Duration duration = Duration.ofHours(5).plusSeconds(50);
+    final LocalDateTime expirationDate = LocalDateTime.now().plus(period).plus(duration);
+
+    final MegaCmdExport megaCmdExport = new MegaCmdExport("/megacmd/anyfolder")
+        .setExpireDate(expirationDate);
+
+    Assertions.assertTrue(megaCmdExport.expirationTimeDelay.isPresent());
+
+    final TimeDelay expirationTimeDelay = megaCmdExport.expirationTimeDelay.get();
+
+    Assertions.assertEquals(expirationTimeDelay.getPeriod().getYears(), period.getYears());
+    Assertions.assertEquals(expirationTimeDelay.getPeriod().getMonths(), period.getMonths());
+    Assertions.assertEquals(expirationTimeDelay.getDuration().toHours(), duration.toHours());
+    Assertions.assertEquals(expirationTimeDelay.getDuration().toMinutes(), duration.toMinutes());
+  }
+
+  @DisplayName("MegaCmdExport#setExpireDate using DateTime should produce the right TimeDelay")
+  @Test
+  public void setExpireDateWithLocalDate() {
+    final Period period = Period.ofDays(2);
+    final LocalDate endDate = LocalDate.now().plus(period);
+
+    final MegaCmdExport megaCmdExport = new MegaCmdExport("/megacmd/anyfolder")
+        .setExpireDate(endDate);
+
+    Assertions.assertTrue(megaCmdExport.expirationTimeDelay.isPresent());
+
+    final TimeDelay expirationTimeDelay = megaCmdExport.expirationTimeDelay.get();
+
+    Assertions.assertEquals(expirationTimeDelay.getPeriod().getDays(), period.getDays());
+    Assertions.assertEquals(expirationTimeDelay.getDuration(), Duration.ZERO);
+  }
+}

--- a/src/test/java/io/github/eliux/mega/cmd/MegaUtilsTest.java
+++ b/src/test/java/io/github/eliux/mega/cmd/MegaUtilsTest.java
@@ -1,6 +1,11 @@
 package io.github.eliux.mega.cmd;
 
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.YEARS;
+
 import io.github.eliux.mega.MegaUtils;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.Month;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/io/github/eliux/mega/cmd/MegaUtilsTest.java
+++ b/src/test/java/io/github/eliux/mega/cmd/MegaUtilsTest.java
@@ -1,11 +1,6 @@
 package io.github.eliux.mega.cmd;
 
-import static java.time.temporal.ChronoUnit.DAYS;
-import static java.time.temporal.ChronoUnit.HOURS;
-import static java.time.temporal.ChronoUnit.YEARS;
-
 import io.github.eliux.mega.MegaUtils;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.Month;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/io/github/eliux/mega/cmd/TimeDelayTest.java
+++ b/src/test/java/io/github/eliux/mega/cmd/TimeDelayTest.java
@@ -1,0 +1,157 @@
+package io.github.eliux.mega.cmd;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TimeDelayTest")
+public class TimeDelayTest {
+
+  @Test
+  public void getYearsUsingPeriodShouldBeOk() {
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofYears(1));
+
+    Assertions.assertEquals(1L, timeDelay.get(ChronoUnit.YEARS));
+  }
+
+  @Test
+  public void getDaysUsingPeriodShouldBeOk() {
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofDays(2));
+
+    Assertions.assertEquals(2L, timeDelay.get(ChronoUnit.DAYS));
+  }
+
+
+  @Test
+  public void getDaysUsingDurationShouldBeOk() {
+    final TimeDelay timeDelay = TimeDelay.of(Duration.ofDays(3));
+
+    Assertions.assertEquals(3L, timeDelay.get(ChronoUnit.DAYS));
+  }
+
+
+  @Test
+  public void getUnitsShouldSupportYEARS() {
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofYears(5));
+
+    Assertions.assertEquals(5, timeDelay.get(ChronoUnit.YEARS));
+  }
+
+  @Test
+  public void getUnitsShouldSupportMONTHS() {
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofMonths(6));
+
+    Assertions.assertEquals(6, timeDelay.get(ChronoUnit.MONTHS));
+  }
+
+
+  @Test
+  public void getUnitsShouldSupportHOURS() {
+    final TimeDelay timeDelay = TimeDelay.of(Duration.ofHours(6));
+
+    Assertions.assertEquals(6, timeDelay.get(ChronoUnit.HOURS));
+  }
+
+
+  @Test
+  public void getUnitsShouldSupportMinutes() {
+    final TimeDelay timeDelay = TimeDelay.of(Duration.ofMinutes(7));
+
+    Assertions.assertEquals(7, timeDelay.get(ChronoUnit.MINUTES));
+  }
+
+
+  @Test
+  public void getUnitsShouldSupportSECONDS() {
+    final TimeDelay timeDelay = TimeDelay.of(Duration.ofSeconds(9));
+
+    Assertions.assertEquals(9, timeDelay.get(ChronoUnit.SECONDS));
+  }
+
+  @Test
+  public void addToLocalDateShouldBeOk() {
+    final LocalDate date = LocalDate.of(2020, 04, 01);
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofYears(1).plusMonths(1));
+
+    final LocalDate result = date.plus(timeDelay);
+
+    Assertions.assertEquals(LocalDate.of(2021, 05, 01), result);
+  }
+
+  @Test
+  public void addToLocalDateTimeShouldBeOk() {
+    final LocalDateTime dateTime = LocalDateTime.of(2020, 04, 01, 0, 30, 5, 0);
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofDays(3), Duration.ofSeconds(6));
+
+    final LocalDateTime result = dateTime.plus(timeDelay);
+
+    final LocalDateTime expectedResult = LocalDateTime.of(2020, 04, 04, 0, 30, 11, 0);
+    Assertions.assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public void subtractFromLocalDateShouldBeOk() {
+    final LocalDate date = LocalDate.of(2020, 04, 01);
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofYears(1).plusMonths(2));
+
+    final LocalDate result = date.minus(timeDelay);
+
+    Assertions.assertEquals(LocalDate.of(2019, 02, 01), result);
+  }
+
+  @Test
+  public void subtractFromLocalDateTimeShouldBeOk() {
+    final LocalDateTime dateTime = LocalDateTime.of(2020, 04, 1, 1, 0, 0, 10);
+    final TimeDelay timeDelay = TimeDelay.of(Period.ofMonths(5), Duration.ofNanos(10));
+
+    final LocalDateTime result = dateTime.minus(timeDelay);
+
+    final LocalDateTime expectedResult = LocalDateTime.of(2019, 11, 1, 1, 0, 0, 0);
+    Assertions.assertEquals(expectedResult, result);
+  }
+
+  @DisplayName("TimeDelay#toString should return 0m")
+  @org.junit.jupiter.api.Test
+  public void toTimeDelayWithZERO() {
+    Assertions.assertEquals("0m", TimeDelay.ZERO.toString());
+  }
+
+
+  @DisplayName("TimeDelay#toString should return 12d3h1m")
+  @org.junit.jupiter.api.Test
+  public void toTimeDelayWithDurationOnly() {
+    final TimeDelay timeDelay = TimeDelay.of(
+        Duration.ofDays(12).plusHours(3).plusMinutes(1)
+    );
+
+    Assertions.assertEquals("12d3h1m", timeDelay.toString());
+  }
+
+
+  @DisplayName("TimeDelay#toString should return 3y11m15d")
+  @org.junit.jupiter.api.Test
+  public void toTimeDelayWithPeriodOnly() {
+    final TimeDelay timeDelay = TimeDelay.of(
+        Period.ofYears(3).plusMonths(11).plusDays(15)
+    );
+
+    Assertions.assertEquals("3y11m15d", timeDelay.toString());
+  }
+
+
+  @DisplayName("TimeDelay#toString should return 5y2m4d11h1m31s")
+  @org.junit.jupiter.api.Test
+  public void toTimeDelayWithPeriodAndDuration() {
+    final TimeDelay timeDelay = TimeDelay.of(
+        Period.ofYears(5).plusMonths(2).plusDays(4),
+        Duration.ofHours(11).plusMinutes(1).plusSeconds(31)
+    );
+
+    Assertions.assertEquals("5y2m4d11h1m31s", timeDelay.toString());
+  }
+}


### PR DESCRIPTION
  
# Description

This option allows to specify an expiration date to the command `export`.
With a premium mega account, you can export and generate public folder links by setting the option `expire date`.
```java
    LocalDate expireDate = LocalDate.of(2020, 9, 2);
    final ExportInfo exportInfo = sessionMega.export(exportFolder)
            .setExpireDate(expireDate)
            .call();
```

or you can just specify a duration using `TimeDelay`.

```java  
    final ExportInfo exportInfo = sessionMega.export(exportFolder)
        .setExpirationTimeDelay(TimeDelay.of(
             Period.ofYears(3).plusMonths(11).plusDays(15)
         ))
        .call();
```

As it seems that all the time delays would have the format presented by MegaCmd:

> It indicates the delay in hours(h), days(d),
> minutes(M), seconds(s), months(m) or years(y)
> e.g. "1m12d3h" establish an expiration time 1 month,
> 12 days and 3 hours after the current moment

Instead of using a Representer Pattern, the aforementioned format was returned by the `toString` function of `TimeDelay`. In case that we actually require another representation for a `TimeDelay`, then such part will be refactored and moved to a `Representer` like class.

Further e2e tests will be added by @ccenyo in order to test whether this feature actually works.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] Automated tests 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules