### PR TITLE
ignore out of storage banner

### DIFF
--- a/src/main/java/io/github/eliux/mega/MegaUtils.java
+++ b/src/main/java/io/github/eliux/mega/MegaUtils.java
@@ -105,6 +105,14 @@ public interface MegaUtils {
     return succeeded ? process.exitValue() : -1;
   }
 
+  String[] RUNNING_OUT_OF_STORAGE_BANNER = new String[]{
+          "-------------------------------------------------------------------------------",
+          "|                   You are running out of available storage.                   |",
+          "|        You can change your account plan to increase your quota limit.         |",
+          "|                   See \"help --upgrade\" for further details.                   |",
+          "-------------------------------------------------------------------------------"
+  };
+
   static List<String> handleCmdWithOutput(String... cmd)
       throws java.io.IOException {
     ProcessBuilder pb = new ProcessBuilder(cmd);
@@ -117,8 +125,15 @@ public interface MegaUtils {
 
     final List<String> result = new ArrayList<>();
 
+    int runningOutOfStorage = 0;
     while (inputScanner.hasNext()) {
-      result.add(inputScanner.next());
+      String line = inputScanner.next();
+        if (runningOutOfStorage < RUNNING_OUT_OF_STORAGE_BANNER.length
+                && line.trim().equals(RUNNING_OUT_OF_STORAGE_BANNER[runningOutOfStorage])) {
+          runningOutOfStorage++;
+        } else {
+          result.add(line);
+        }
     }
 
     process.destroy();


### PR DESCRIPTION
<!-- Add or remove details as needed for your own specific use cases. -->
      
# Description

Since my mega account is almost full, mega-cmd always displays a banner like this:
```
 ----------------------------------------------------------------------------------------------------------------------------------------
|                                               You are running out of available storage.                                                |
|                                     You can change your account plan to increase your quota limit.                                     |
|                                                See "help --upgrade" for further details                                                |
 ----------------------------------------------------------------------------------------------------------------------------------------
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Called `Mega.init()` using my mega account.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules