### PR TITLE
Fix filename space

### DIFF
--- a/src/main/java/io/github/eliux/mega/cmd/FileInfo.java
+++ b/src/main/java/io/github/eliux/mega/cmd/FileInfo.java
@@ -4,7 +4,9 @@ import io.github.eliux.mega.MegaUtils;
 import io.github.eliux.mega.error.MegaInvalidResponseException;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Defines a remote file/Folder in MEGA
@@ -58,9 +60,11 @@ public class FileInfo {
         final String[] tokens = fileInfoStr.replace("\\t", "\\s").split("\\s+");
 
         if (tokens.length != 6) {
-            throw new MegaInvalidResponseException(
-                    "The gotten file format is incorrect: Should have 6 tokens"
-            );
+            //Instead of throwing an exception when we receive more than 6 tokens, we concatenate the last tokens.length - 6 tokens into one
+            String[] newTokens = new String[6];
+            System.arraycopy(tokens, 0, newTokens, 0, 5);
+            newTokens[5] = Arrays.stream(tokens).skip(5).collect(Collectors.joining(" "));
+            return newTokens;
         }
 
         return tokens;

--- a/src/main/java/io/github/eliux/mega/cmd/MegaCmdList.java
+++ b/src/main/java/io/github/eliux/mega/cmd/MegaCmdList.java
@@ -35,8 +35,11 @@ public class MegaCmdList extends AbstractMegaCmdCallerWithParams<List<FileInfo>>
 
     @Override
     public List<FileInfo> call() {
+        //mega-cmd seems to print a line with the directory name before the usual "FLAGS VERS    SIZE            DATE       NAME" line when the path contains a space
+        int skipNLines = remotePath.contains(" ") ? 2 : 1;
+
         try {
-            return MegaUtils.handleCmdWithOutput(executableCommandArray()).stream().skip(1)
+            return MegaUtils.handleCmdWithOutput(executableCommandArray()).stream().skip(skipNLines)
                     .filter(FileInfo::isValid)  //To avoid complementary info
                     .map(FileInfo::parseInfo)
                     .collect(Collectors.toList());


### PR DESCRIPTION
<!-- Add or remove details as needed for your own specific use cases. -->
      
# Description
When calling `MegaCmdList#ls` files with spaces are just ignored. This PR fixes this. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Create a file with a space
2. Run a `MegaCmdList#ls` in the directory of the file
3. It now shows up in the list
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules