### PR TITLE
Ignore banner at the beginning of the cmd output #32

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,19 +23,11 @@ Please also list any relevant details for your test configuration
 - [ ] Test A
 - [ ] Test B
 
-**Test Configuration**:
-* Firmware version:
-* Hardware:
-* Toolchain:
-* SDK:
-
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules

--- a/src/main/java/io/github/eliux/mega/MegaUtils.java
+++ b/src/main/java/io/github/eliux/mega/MegaUtils.java
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
@@ -32,7 +33,7 @@ public interface MegaUtils {
       .ofPattern("ddMMMyyyy HH:mm:ss", Locale.US);
 
   DateTimeFormatter MEGA_EXPORT_EXPIRE_DATE_FORMATTER = DateTimeFormatter
-          .ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
+      .ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
 
   Pattern EMAIL_PATTERN = Pattern.compile(
       "^[\\w]+@[\\w]+\\.[a-zA-Z]{2,6}$",
@@ -48,12 +49,18 @@ public interface MegaUtils {
       .map(Integer::new)
       .orElse(20000);
 
+
+  Pattern BANNER_PATTERN = Pattern.compile(
+      "^\\s?(-){5,}(.+)(-){5,}\\R",
+      Pattern.MULTILINE | Pattern.DOTALL
+  );
+
   static LocalDateTime parseFileDate(String dateStr) {
     return LocalDateTime.parse(dateStr, MEGA_FILE_DATE_TIME_FORMATTER);
   }
 
   static LocalDate parseBasicISODate(String dateStr) {
-    return  LocalDateTime.parse(dateStr, MEGA_EXPORT_EXPIRE_DATE_FORMATTER).toLocalDate();
+    return LocalDateTime.parse(dateStr, MEGA_EXPORT_EXPIRE_DATE_FORMATTER).toLocalDate();
   }
 
   static void handleResult(int code) {
@@ -148,5 +155,19 @@ public interface MegaUtils {
 
   static boolean isDirectory(String token) {
     return !isEmail(token) && DIRECTORY_PATTERN.matcher(token).find();
+  }
+
+  static List<String> collectValidCmdOutput(Scanner inputScanner) {
+    final List<String> result = new ArrayList<>();
+
+    try {
+      inputScanner.skip(BANNER_PATTERN);
+    } catch (NoSuchElementException ex) { }
+
+    while (inputScanner.hasNext()) {
+      result.add(inputScanner.next());
+    }
+
+    return result;
   }
 }

--- a/src/test/java/io/github/eliux/mega/cmd/MegaUtilsTest.java
+++ b/src/test/java/io/github/eliux/mega/cmd/MegaUtilsTest.java
@@ -3,6 +3,8 @@ package io.github.eliux.mega.cmd;
 import io.github.eliux.mega.MegaUtils;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.List;
+import java.util.Scanner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,5 +60,52 @@ public class MegaUtilsTest {
   public void isDirectoryShouldFail() {
     Assertions.assertFalse(MegaUtils.isDirectory("user@doma.in"));
     //TODO Improve
+  }
+
+  @DisplayName("MegaUtils#collectValidCmdOutput should not accept output with banner")
+  @Test
+  public void collectValidCmdOutputShouldNotAcceptOutputWithStoreBanner() {
+    final String OUTPUT_WITH_RUNNING_OUT_OF_STORAGE_BANNER =
+            "-------------------------------------------------------------------------------\n" +
+            "|                   You are running out of available storage.                   |\n" +
+            "|        You can change your account plan to increase your quota limit.         |\n" +
+            "|                   See \"help --upgrade\" for further details.                 |\n" +
+            "--------------------------------------------------------------------------------\n" +
+            "MEGAcmd version: 1.3.0.0: code 1030000\n" +
+            "MEGA SDK version: 3.7.0\n";
+    final Scanner inputScanner = new Scanner(OUTPUT_WITH_RUNNING_OUT_OF_STORAGE_BANNER)
+        .useDelimiter("\n");
+
+    final List<String> result = MegaUtils.collectValidCmdOutput(inputScanner);
+
+    Assertions.assertEquals( 2, result.size());
+    Assertions.assertEquals( "MEGAcmd version: 1.3.0.0: code 1030000", result.get(0));
+    Assertions.assertEquals("MEGA SDK version: 3.7.0", result.get(1));
+  }
+
+  @DisplayName("MegaUtils#collectValidCmdOutput should not trim alike content when banner is over")
+  @Test
+  public void collectValidCmdOutputShouldNotTrimAlikeContentWhenBannerIsOver() {
+    final String CONFUSING_BANNER =
+            "-------------------------------------------------------------------------------\n" +
+            "|                   You are running out of available storage.                   |\n" +
+            "|        You can change your account plan to increase your quota limit.         |\n" +
+            "|                   See \"help --upgrade\" for further details.                 |\n" +
+            "--------------------------------------------------------------------------------\n" +
+            "These are the results\n" +
+            "|----------------------------|\n" +
+            "|asd | vvvvv | zzzzz   | tttt|\n" +
+            "|----------------------------|\n";
+
+    final Scanner inputScanner = new Scanner(CONFUSING_BANNER)
+        .useDelimiter("\n");
+
+    final List<String> result = MegaUtils.collectValidCmdOutput(inputScanner);
+
+    Assertions.assertEquals(4, result.size());
+    Assertions.assertEquals("These are the results", result.get(0));
+    Assertions.assertEquals("|----------------------------|", result.get(1));
+    Assertions.assertEquals("|asd | vvvvv | zzzzz   | tttt|", result.get(2));
+    Assertions.assertEquals("|----------------------------|", result.get(3));
   }
 }


### PR DESCRIPTION
This trims any initial banner like:

```
 ----------------------------------------------------------------------------------------------------------------------------------------
|                                               You are running out of available storage.                                                |
|                                     You can change your account plan to increase your quota limit.                                     |
|                                                See "help --upgrade" for further details                                                |
 ----------------------------------------------------------------------------------------------------------------------------------------
```

Fixes issue described in PR #32 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [X] MegaUtils#collectValidCmdOutput should not accept output with banner
- [X] MegaUtils#collectValidCmdOutput should not trim alike content when banner is over


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes