### PR TITLE
Collect only valid output in `handleCmdWithOutput`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: java
 sudo: required
 env:
  - MEGA_CMD_TTL=30000
+jdk:
+ - oraclejdk11
+
 before_install:
  #Megacmd required ubuntu packages
  - sudo apt-get -y install libc-ares2 libcrypto++9 libmediainfo0 libzen0

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,7 @@
   <url>http://github.com/EliuX/MEGAcmd4J</url>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -152,9 +151,22 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
+      </plugin>
+      <!-- Required for tests with junit5 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M6</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <!-- Executed by Travis and triggered by release:prepare -->
       <plugin>

--- a/src/main/java/io/github/eliux/mega/MegaUtils.java
+++ b/src/main/java/io/github/eliux/mega/MegaUtils.java
@@ -122,11 +122,7 @@ public interface MegaUtils {
     final Scanner inputScanner = new Scanner(process.getInputStream())
         .useDelimiter(System.getProperty("line.separator"));
 
-    final List<String> result = new ArrayList<>();
-
-    while (inputScanner.hasNext()) {
-      result.add(inputScanner.next());
-    }
+    final List<String> result = MegaUtils.collectValidCmdOutput(inputScanner);
 
     process.destroy();
 

--- a/src/main/java/io/github/eliux/mega/cmd/AbstractMegaCmd.java
+++ b/src/main/java/io/github/eliux/mega/cmd/AbstractMegaCmd.java
@@ -2,9 +2,7 @@ package io.github.eliux.mega.cmd;
 
 import io.github.eliux.mega.MegaUtils;
 import io.github.eliux.mega.platform.OSPlatform;
-
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public abstract class AbstractMegaCmd<T> {


### PR DESCRIPTION
<!-- Add or remove details as needed for your own specific use cases. -->
      
# Description
The codebase for this solution was added a long time ago yet not enforced as it should, my apologies for that. This will ignore all banners, no matter its reason and just focus on the command that it needs to execute.

Fixes #43

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] MegaUtils#collectValidCmdOutput should not accept output with banner
- [x] MegaUtils#collectValidCmdOutput should not trim alike content when banner is over
- [ ]  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
